### PR TITLE
Stretch compat

### DIFF
--- a/conf/packages
+++ b/conf/packages
@@ -1,4 +1,4 @@
-libgdal1
+libgdal1 | libgdal20
 memcached
 python-virtualenv
 libapache2-mod-wsgi

--- a/conf/pre_deploy_actions.bash
+++ b/conf/pre_deploy_actions.bash
@@ -23,8 +23,7 @@ fi
 source $virtualenv_activate
 
 # Upgrade pip to a secure version
-curl --silent --location https://bootstrap.pypa.io/get-pip.py | python - 'pip<9'
-pip install distribute==0.7.3
+curl -L -s https://raw.github.com/mysociety/commonlib/master/bin/get_pip.bash | bash
 # Improve SSL behaviour
 pip install pyOpenSSL ndg-httpsclient pyasn1
 


### PR DESCRIPTION
This adds Stretch compatibility by including `libgdal20` as an alternative in the package lists. It also uses the `get_pip.bash` script from commonlib when setting up the virtualenv.