### PR TITLE
Python3 migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 .venv
 .static
 .vagrant
+.python-version

--- a/conf/general.yml-example
+++ b/conf/general.yml-example
@@ -38,3 +38,7 @@ RATE_LIMIT:
 # Email address that errors should be sent to. Optional.
 BUGS_EMAIL: 'example@example.org'
 EMAIL_SUBJECT_PREFIX: '[International MapIt] '
+
+# Default for implicit primary key type. For projects with Django >=3.2
+# may wish to use a different setting.
+DEFAULT_AUTO_FIELD: 'django.db.models.AutoField'

--- a/conf/packages
+++ b/conf/packages
@@ -1,14 +1,9 @@
-libgdal1 | libgdal20
+libapache2-mod-wsgi-py3
 memcached
-python-virtualenv
-libapache2-mod-wsgi
 
-python-dev
-libssl-dev
 libffi-dev
+libgdal-dev
+libpq-dev
+libssl-dev
+python3-dev
 
-python-psycopg2
-python-shapely
-python-yaml
-python-memcache
-python-gdal

--- a/conf/pre_deploy_actions.bash
+++ b/conf/pre_deploy_actions.bash
@@ -10,20 +10,23 @@ cd "$(dirname $BASH_SOURCE)"/..
 # them back to the defaults which is what they would have on the servers.
 PYTHONDONTWRITEBYTECODE=""
 
-# create the virtual environment; we always want system packages
-virtualenv_args="--system-site-packages"
+# create the virtual environment
 virtualenv_dir='.venv'
 virtualenv_activate="$virtualenv_dir/bin/activate"
 
 if [ ! -f "$virtualenv_activate" ]
 then
-    virtualenv $virtualenv_args $virtualenv_dir
+    python3 -m venv $virtualenv_dir
 fi
 
 source $virtualenv_activate
 
-# Upgrade pip to a secure version
-curl -L -s https://raw.github.com/mysociety/commonlib/master/bin/get_pip.bash | bash
+# Install wheel
+pip install wheel
+
+# Install the correct version of GDAL
+pip install gdal==$(gdal-config --version)
+
 # Improve SSL behaviour
 pip install pyOpenSSL ndg-httpsclient pyasn1
 

--- a/mapit_international/management/commands/mapit_international_import_circonscriptions.py
+++ b/mapit_international/management/commands/mapit_international_import_circonscriptions.py
@@ -76,7 +76,7 @@ class Command(BaseCommand):
         layer = ds[0]
         with transaction.atomic():
             for feature in layer:
-                ref = unicode(feature['REF'])
+                ref = str(feature['REF'])
                 ref_to_polygons[ref].append(feature.geom)
-            for ref, polygons in ref_to_polygons.items():
+            for ref, polygons in list(ref_to_polygons.items()):
                 self.update_area(ref, polygons)

--- a/mapit_international/management/commands/mapit_international_import_eur.py
+++ b/mapit_international/management/commands/mapit_international_import_eur.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function, unicode_literals
+
 
 from collections import defaultdict
 import re
@@ -121,14 +121,14 @@ DEPARTMENT_TO_EUR = {
 
 
 EUR_ID_TO_NAME = {
-    'est': u'Est',
-    'ile-de-france': u'Île-de-France',
-    'massif-central-centre': u'Massif Central-Centre',
-    'nord-ouest': u'Nord-Ouest',
-    'ouest': u'Ouest',
-    'outre-mer': u'Outre-Mer',
-    'sud-est': u'Sud-Est',
-    'sud-ouest': u'Sud-Ouest',
+    'est': 'Est',
+    'ile-de-france': 'Île-de-France',
+    'massif-central-centre': 'Massif Central-Centre',
+    'nord-ouest': 'Nord-Ouest',
+    'ouest': 'Ouest',
+    'outre-mer': 'Outre-Mer',
+    'sud-est': 'Sud-Est',
+    'sud-ouest': 'Sud-Ouest',
 }
 
 
@@ -210,9 +210,9 @@ class Command(BaseCommand):
         layer = ds[0]
         with transaction.atomic():
             for feature in layer:
-                insee_code = unicode(feature['code_insee'])
+                insee_code = str(feature['code_insee'])
                 code_key = re.sub(r'^0*', '', insee_code)
                 eur_id = DEPARTMENT_TO_EUR[code_key]
                 eur_id_to_polygons[eur_id].append(feature.geom)
-            for eur_id, polygons in eur_id_to_polygons.items():
+            for eur_id, polygons in list(eur_id_to_polygons.items()):
                 self.update_area(eur_id, polygons)

--- a/mapit_international/mapit_settings.py
+++ b/mapit_international/mapit_settings.py
@@ -231,3 +231,5 @@ LOGGING = {
 }
 
 DATE_FORMAT = 'j F Y'
+
+DEFAULT_AUTO_FIELD = config.get('DEFAULT_AUTO_FIELD', 'django.db.models.AutoField')

--- a/mapit_international/settings.py
+++ b/mapit_international/settings.py
@@ -1,6 +1,6 @@
 # Import MapIt's settings (first time to quiet flake8)
-from mapit_settings import INSTALLED_APPS
-from mapit_settings import *  # noqa
+from .mapit_settings import INSTALLED_APPS
+from .mapit_settings import *  # noqa
 
 # Update a couple of things to suit our changes
 

--- a/mapit_international/urls.py
+++ b/mapit_international/urls.py
@@ -2,6 +2,6 @@ from django.conf.urls import include, url
 from django.contrib import admin
 
 urlpatterns = [
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
     url(r'^', include('mapit.urls')),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
-Django==1.11.29
+Django==3.2.13
 psycopg2 >= 2.5.4
 -e git+https://github.com/mysociety/mapit.git@master#egg=django-mapit
+Shapely==1.7.1
+PyYAML==5.3.1
+python-memcached==1.59


### PR DESCRIPTION
Some small fixes to code via `2to3` and related bits to enable a deploy using Python 3 and Django 3.2. We'll look at the question of the development environment separately.